### PR TITLE
Make some fixes to cron to keep repo up to date

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -7,6 +7,8 @@ on:
 jobs:
   sync:
     runs-on: ubuntu-latest
+    # Run only on main branch in upstream repo.
+    if github.repository == 'scientific-python-translations/pandas-translations' && github.ref == 'refs/heads/main'
     steps:
       - name: Checkout pandas
         uses: actions/checkout@v2

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Sync the website content
         run: |
-          rsync -av --delete pandas/pandas/web/pandas/ pandas-translations/content/en/
+          rsync -av --delete pandas/web/pandas/ pandas-translations/content/en/
           cd pandas-translations
           git config --global user.email "actions@github.com"
           git config --global user.name "GitHub Actions"


### PR DESCRIPTION
This PR fixes the path to the pandas website content used in the rsync command, and also ensures this cron will only run on the main branch of the upstream repo.