### PR TITLE
Avoid creating new branches in sync workflow if content has not been updated.

### DIFF
--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -42,9 +42,8 @@ jobs:
           else
             git commit -m "Update website content"
             echo "CONTENT_CHANGED=true" >> $GITHUB_ENV
+            git push -u origin ${{ env.BRANCH_NAME }}
           fi
-          git commit -m "Update website content" -a || echo "No changes to commit"
-          git push -u origin ${{ env.BRANCH_NAME }}
 
       - name: Create Pull Request
         if: env.CONTENT_CHANGED == 'true'


### PR DESCRIPTION
I've noticed that a new branch is created each day in this repo by the sync.yml workflow which syncs the content here with that in the Pandas repo. This was due to a bug in the script where the push was placed outside of the else block which runs when content is updated. This is fixed in this PR.