### PR TITLE
Add github workflow to check for do-not-merge label

### DIFF
--- a/.github/workflows/do_not_merge.yml
+++ b/.github/workflows/do_not_merge.yml
@@ -1,0 +1,18 @@
+name: Check for "do-not-merge" label
+
+on:
+  pull_request:
+    types: [labeled, unlabeled, synchronize, opened]
+
+jobs:
+  check_do_not_merge_label:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check for "do-not-merge" Label
+        id: check_label
+        # https://stackoverflow.com/a/71510189/992102
+        if: contains(github.event.pull_request.labels.*.name, 'do-not-merge')
+        run: |
+          echo "DO NOT MERGE"
+          exit 1


### PR DESCRIPTION
This PR adds a workflow to check PRs for the do-not-merge label. If the label is found, the workflow fails. Coupled with a branch protection rule to disallow merging pull requests when all checks have failed, this enforces that PRs with the do-not-merge label cannot be merged.